### PR TITLE
Remove code for features that don't help with the goal of GmailScheduler

### DIFF
--- a/src/Globals.gs
+++ b/src/Globals.gs
@@ -7,7 +7,6 @@ var SCHEDULER_LABEL = 'GScheduler';
 var SCHEDULER_TIMER_LABEL = 'Timer';
 var SCHEDULER_QUEUE_LABEL = 'Queue';
 var SCHEDULER_EXTRAS_LABEL = 'Extras';
-var SCHEDULER_SMS_LABEL = 'Sms';
 
 // Use default google calendar to determine user timezone
 var DEFAULT_TIMEZONE = 'default';
@@ -30,7 +29,6 @@ var DEFAULT_PREFS = {
   move_sent_messages_inbox:        true,
   mark_sent_messages_inbox_unread: false,
   nolabel_drafs_to_inbox:          false,
-  send_message_sms:                false,
   localzone:                       'default',
   timer:                           [ '1 hour later',
                                      '2 hours later',

--- a/src/Main.gs
+++ b/src/Main.gs
@@ -5,7 +5,6 @@ function setupStaticLabels () {
 
   // Extras
   GmailApp.createLabel(SCHEDULER_LABEL + '/' + SCHEDULER_EXTRAS_LABEL)
-  GmailApp.createLabel(SCHEDULER_LABEL + '/' + SCHEDULER_EXTRAS_LABEL + '/' + SCHEDULER_SMS_LABEL)
 }
 
 function sendWelcomeEmail () {

--- a/src/Main.gs
+++ b/src/Main.gs
@@ -9,8 +9,6 @@ function setupStaticLabels () {
 }
 
 function sendWelcomeEmail () {
-  var userPrefs = getUserPrefs(false)
-
   var body = 'Hi there,'
   body += '<p>Thanks for trying out the GmailScheduler. This is a free, secure, private (data is held only within your gmail account &amp; your google app script) and convenient method to schedule outgoing messages and return messages to your inbox.</p>'
   body += '<p>GmailScheduler is an open-source project. Please submit tickets for any issues that you find to the <a href="https://github.com/webdigi/GmailScheduler/issues">issue tracker</a>.</p>'
@@ -19,6 +17,7 @@ function sendWelcomeEmail () {
     htmlBody: body
   }
 
+  var userPrefs = getUserPrefs(false)
   if (!userPrefs['email_welcome_sent']) {
     GmailApp.sendEmail(getActiveUserEmail(), EMAIL_WELCOME_SUBJECT, body, options)
     userPrefs['email_welcome_sent'] = true
@@ -27,58 +26,20 @@ function sendWelcomeEmail () {
 }
 
 /////////// OUTGOING SENT MSG
-function dispatchDraft (id) {
-  try {
-    var message = GmailApp.getMessageById(id)
+function dispatchDraft (messageId) {
+    var message = GmailApp.getMessageById(messageId)
 
     if (message) {
-      var body = message.getBody()
-      var raw  = message.getRawContent()
-      var inlineImages = {}
-
-      /* Credit - YetAnotherMailMerge */
-
-      var regMessageId = new RegExp(id, 'g')
-      if (body.match(regMessageId) !== null) {
-        var imgVars = body.match(/<img[^>]+>/g)
-        var imgToReplace = []
-
-        if (imgVars !== null) {
-          for (var i = 0; i < imgVars.length; i++) {
-            if (imgVars[i].search(regMessageId) != -1) {
-              var imgId = imgVars[i].match(/realattid=([^&]+)&/)
-              if (imgId !== null) {
-                imgId = imgId[1]
-                var temp = raw.split(imgId)[1]
-                temp = temp.substr(temp.lastIndexOf('Content-Type'))
-                var imgTitle = temp.match(/name="([^"]+)"/)
-                var contentType = temp.match(/Content-Type: ([^;]+);/)
-                contentType = (contentType !== null) ? contentType[1] : 'image/jpeg'
-                var b64c1 = raw.lastIndexOf(imgId) + imgId.length + 3 // first character in image base64
-                var b64cn = raw.substr(b64c1).indexOf('--') - 3 // last character in image base64
-                var imgb64 = raw.substring(b64c1, b64c1 + b64cn + 1); // is this fragile or safe enough?
-                var imgblob = Utilities.newBlob(Utilities.base64Decode(imgb64), contentType, imgId) // decode and blob
-                if (imgTitle !== null) imgToReplace.push([imgTitle[1], imgVars[i], imgId, imgblob])
-              }
-            }
-          }
-        }
-
-        for (var z = 0; z < imgToReplace.length; z++) {
-          inlineImages[imgToReplace[z][2]] = imgToReplace[z][3]
-          var newImg = imgToReplace[z][1].replace(/src="[^\"]+\"/, 'src="cid:' + imgToReplace[z][2] + '"')
-          body = body.replace(imgToReplace[z][1], newImg)
-        }
-      }
-
+      var body = getBodyFromMessage(message)
+      var inlineImages = getInlineImagesFromMessage(message)
       var options = {
-        cc: message.getCc(),
-        bcc: message.getBcc(),
-        htmlBody: body,
-        replyTo: message.getReplyTo(),
-        inlineImages: inlineImages,
-        name: message.getFrom().match(/[^<]*/)[0].trim(),
-        attachments: message.getAttachments()
+          cc: message.getCc(),
+          bcc: message.getBcc(),
+          htmlBody: body,
+          replyTo: message.getReplyTo(),
+          inlineImages: inlineImages,
+          name: message.getFrom().match(/[^<]*/)[0].trim(),
+          attachments: message.getAttachments()
       }
 
       GmailApp.sendEmail(message.getTo(), message.getSubject(), body, options)
@@ -87,10 +48,75 @@ function dispatchDraft (id) {
     } else {
       return 'Message not found in Drafts'
     }
+}
 
-  // TODO: Remove this error handling, and see what specific errors crop up
-  // so that we can handle them explicitly.
-  } catch (e) {
-    return e.toString()
+function getBodyFromMessage(message){
+    var body = message.getBody()
+    var raw  = message.getRawContent()
+    var regMessageId = new RegExp(message.getId(), 'g')
+
+    if (body.match(regMessageId) !== null) {
+      var imgVars = body.match(/<img[^>]+>/g)
+      var imgToReplace = generateImgToReplace(imgVars, regMessageId, raw)
+      body = replaceImagesInBody(imgToReplace, body)
+    }
+    return body
+}
+
+function getInlineImagesFromMessage(message){
+    var body = message.getBody()
+    var raw  = message.getRawContent()
+    var inlineImages = {}
+    var regMessageId = new RegExp(message.getId(), 'g')
+
+    if (body.match(regMessageId) !== null) {
+      var imgVars = body.match(/<img[^>]+>/g)
+      var imgToReplace = generateImgToReplace(imgVars, regMessageId, raw)
+      inlineImages = generateInlineImages(imgToReplace)
+    }
+    return inlineImages
+}
+
+function generateInlineImages(images){
+    var inlineImages = {}
+    for (var z = 0; z < images.length; z++) {
+        inlineImages[images[z][2]] = images[z][3]
+    }
+    return inlineImages
+}
+
+function replaceImagesInBody(imgToReplace, body){
+    var newBody = body
+    for (var z = 0; z < imgToReplace.length; z++) {
+        var newImg = imgToReplace[z][1].replace(/src="[^\"]+\"/, 'src="cid:' + imgToReplace[z][2] + '"')
+        newBody = newBody.replace(imgToReplace[z][1], newImg)
+    }
+    return newBody
+}
+
+function generateImgToReplace(imgVars, regMessageId, raw){
+  var imgToReplace = []
+  if (imgVars !== null) {
+    for (var i = 0; i < imgVars.length; i++) {
+      if (imgVars[i].search(regMessageId) != -1) {
+        var imgId = imgVars[i].match(/realattid=([^&]+)&/)
+        if (imgId !== null) {
+          imgId = imgId[1]
+          var temp = raw.split(imgId)[1]
+          temp = temp.substr(temp.lastIndexOf('Content-Type'))
+          var imgTitle = temp.match(/name="([^"]+)"/)
+          var contentType = temp.match(/Content-Type: ([^;]+);/)
+          contentType = (contentType !== null) ? contentType[1] : 'image/jpeg'
+          var b64c1 = raw.lastIndexOf(imgId) + imgId.length + 3 // first character in image base64
+          var b64cn = raw.substr(b64c1).indexOf('--') - 3 // last character in image base64
+          var imgb64 = raw.substring(b64c1, b64c1 + b64cn + 1); // is this fragile or safe enough?
+          var imgblob = Utilities.newBlob(Utilities.base64Decode(imgb64), contentType, imgId) // decode and blob
+          if (imgTitle !== null){
+              imgToReplace.push([imgTitle[1], imgVars[i], imgId, imgblob])
+          }
+        }
+      }
+    }
   }
+  return imgToReplace
 }

--- a/src/Main.gs
+++ b/src/Main.gs
@@ -8,6 +8,7 @@ function setupStaticLabels () {
 }
 
 function sendWelcomeEmail () {
+  var userPrefs = getUserPrefs(false)
   var body = 'Hi there,'
   body += '<p>Thanks for trying out the GmailScheduler. This is a free, secure, private (data is held only within your gmail account &amp; your google app script) and convenient method to schedule outgoing messages and return messages to your inbox.</p>'
   body += '<p>GmailScheduler is an open-source project. Please submit tickets for any issues that you find to the <a href="https://github.com/webdigi/GmailScheduler/issues">issue tracker</a>.</p>'
@@ -16,7 +17,6 @@ function sendWelcomeEmail () {
     htmlBody: body
   }
 
-  var userPrefs = getUserPrefs(false)
   if (!userPrefs['email_welcome_sent']) {
     GmailApp.sendEmail(getActiveUserEmail(), EMAIL_WELCOME_SUBJECT, body, options)
     userPrefs['email_welcome_sent'] = true

--- a/src/Prefs.gs
+++ b/src/Prefs.gs
@@ -21,7 +21,6 @@ function getUserPrefs (force_reload) {
   if (USER_PREFS === null || force_reload) {
     debug('User preferences object empty.. reloading..')
     USER_PREFS = new Prefs()
-
   }
   return USER_PREFS
 }

--- a/src/Prefs.gs
+++ b/src/Prefs.gs
@@ -19,23 +19,15 @@ function Prefs () {
 
 function getUserPrefs (force_reload) {
   if (USER_PREFS === null || force_reload) {
-    debug('User preferences object empty.. reloading..')
     USER_PREFS = new Prefs()
   }
   return USER_PREFS
 }
 
 function savePrefsFromForm (form_object) {
-  debug('Saving preferences from form object which contains: ')
-
-  for (var prop in form_object)
-    debug(' - ' + prop + ' => ' + form_object[prop])
-
   PropertiesService.getUserProperties().setProperties(form_object, true)
 
   var prefs = getUserPrefs(true)
-
-  debug('Refreshed preference object now contains:')
 
   var message = 'Saved new preferences.'
 
@@ -52,8 +44,6 @@ function loadPrefsForForm () {
   for (var default_prop in DEFAULT_PREFS) {
     if (prefs[default_prop] === undefined) {
       prefs[default_prop] = DEFAULT_PREFS[default_prop]
-
-      debug('Loading default property for key:' + default_prop + ' value: ' + prefs[default_prop])
     }
   }
 

--- a/src/Triggers.gs
+++ b/src/Triggers.gs
@@ -16,11 +16,6 @@ function createTriggers () {
     .timeBased()
     .everyMinutes(1)
     .create()
-
-  var smsTrigger = ScriptApp.newTrigger('processSms')
-    .timeBased()
-    .everyMinutes(1)
-    .create()
 }
 
 function deleteTriggers () {
@@ -136,33 +131,7 @@ function moveDraftsToInbox () {
   }
 
   var drafts = GmailApp.getDraftMessages()
-
   for (var i = 0; i < drafts.length; i++) {
-    if (drafts[i].getSubject().match(/inbox0/)) {
-      // BONUS: If draft emails have subject inbox0 in them, then do not return those to inbox.
-    } else {
-      // Move to these drafts to inbox
-      drafts[i].getThread().moveToInbox()
-    }
+    drafts[i].getThread().moveToInbox()
   }
-}
-
-function processSms () {
-  var userPrefs = getUserPrefs(false)
-
-  if (!userPrefs['send_message_sms']) {
-    return
-  }
-
-  var smsLabel = SCHEDULER_LABEL + '/' + SCHEDULER_EXTRAS_LABEL + '/' + SCHEDULER_SMS_LABEL
-  var smsLabelObject = GmailApp.getUserLabelByName(smsLabel)
-  var smsLabelThreads = smsLabelObject.getThreads()
-  var now = new Date().getTime()
-  for (i in smsLabelThreads) {
-    CalendarApp.createEvent('IMP- ' + smsLabelThreads[0].getFirstMessageSubject(),
-      new Date(now + 60000),
-      new Date(now + 60000))
-    CalendarApp.createEvent('IMP- ' + smsLabelThreads[0].getFirstMessageSubject(), new Date(now + 60000), new Date(now + 60000)).addSmsReminder(0)
-  }
-  smsLabelObject.removeFromThreads(smsLabelThreads)
 }

--- a/src/Triggers.gs
+++ b/src/Triggers.gs
@@ -27,15 +27,14 @@ function deleteTriggers () {
 }
 
 function processTimer () {
-  debug('processTimer Activated ' + new Date().toString())
-
   var queueLabel = SCHEDULER_LABEL + '/' + SCHEDULER_QUEUE_LABEL
   var queueLabelObject = GmailApp.getUserLabelByName(queueLabel)
   var timerChildLabels = getUserChildLabels(SCHEDULER_LABEL + '/' + SCHEDULER_TIMER_LABEL)
 
   for (var i = 0; i < timerChildLabels.length; i++) {
-    var timerChildLabelObject, page
+    var timerChildLabelObject
     var date = parseDate(timerChildLabels[i])
+    var page = null
 
     if (date === null) {
       continue
@@ -44,7 +43,6 @@ function processTimer () {
     var queueChildLabel = SCHEDULER_LABEL + '/' + SCHEDULER_QUEUE_LABEL + '/' + date.full()
 
     timerChildLabelObject = GmailApp.getUserLabelByName(SCHEDULER_LABEL + '/' + SCHEDULER_TIMER_LABEL + '/' + timerChildLabels[i])
-    page = null
 
     // Get threads in "pages" of 100 at a time
     while(!page || page.length == 100) {
@@ -57,30 +55,26 @@ function processTimer () {
           queueLabelObject.addToThreads(page)
           // Move the threads into queueChildLabel
           queueChildLabelObject.addToThreads(page)
-
         }
         // Move the threads out of timerLabel
         timerChildLabelObject.removeFromThreads(page)
       }
     }
-
   }
 }
 
 function processQueue () {
-  debug('processQueue Activated ' + new Date().toString())
   var userPrefs = getUserPrefs(false)
-
   var queueLabel = SCHEDULER_LABEL + '/' + SCHEDULER_QUEUE_LABEL
   var queueLabelObject = GmailApp.getUserLabelByName(queueLabel)
   var queueChildLabels = getUserChildLabels(SCHEDULER_LABEL + '/' + SCHEDULER_QUEUE_LABEL)
+
   for (var i = 0; i < queueChildLabels.length; i++) {
     var currentDate = convertToUserDate(new Date())
     var queueChildDate = parseDate(queueChildLabels[i])
 
     // skip if queuedatetime is not ready to process
     if (currentDate.getTime() < queueChildDate.getTime()) {
-      debug('process later')
       continue
     }
 
@@ -105,9 +99,7 @@ function processQueue () {
           sentMessage.removeLabel(queueLabelObject)
           sentMessage.removeLabel(queueChildLabelObject)
           sentMessage.moveToInbox()
-
         }
-
       } else {
         thread.removeLabel(queueLabelObject)
         thread.removeLabel(queueChildLabelObject)
@@ -116,10 +108,8 @@ function processQueue () {
         if (userPrefs['mark_sent_messages_inbox_unread']) {
           GmailApp.markMessageUnread(message)
         }
-
       }
     }
-
   }
 }
 

--- a/src/User_UI.html
+++ b/src/User_UI.html
@@ -298,10 +298,6 @@
                 <input type="radio" name="nolabel_drafs_to_inbox" id="nolabel_drafs_to_inbox_true" value=true>Yes, bring all drafts to my inbox</input><br/>
                 <input type="radio" name="nolabel_drafs_to_inbox" id="nolabel_drafs_to_inbox_false" value=false>No</input>
                 </div><br/>
-                <div>{BETA} Send me a text message when a message is set with label SMS<br/>
-                <input type="radio" name="send_message_sms" id="send_message_sms_true" value=true>Yes, send me a text message when emails are labelled with SMS</input><br/>
-                <input type="radio" name="send_message_sms" id="send_message_sms_false" value=false>No, I will try this later</input>
-                </div><br/>
             </fieldset>
             <button class="btn btn-primary" type='button' onclick='if (validate()) savePrefsForm()'>Save Settings</button>
         </form>

--- a/src/User_UI.html
+++ b/src/User_UI.html
@@ -23,7 +23,6 @@
     }
 
     function validate () {
-      debug('Starting validation check.')
       return true
     }
 
@@ -43,7 +42,6 @@
     }
 
     function restorePrefsHandler (prefs_object) {
-      debug('Restoring preferences')
       getHandlers().setupStaticLabels()
 
       // set timezone in display
@@ -63,7 +61,6 @@
         var element = document.getElementById(id_name)
 
         if (element) {
-          debug('    Found as a text box. id:' + element.id + ' value: ' + prefs_object[id_name])
           element.value = prefs_object[id_name]
           continue
         }
@@ -73,11 +70,9 @@
         element = document.getElementById(id_name + '_' + prefs_object[id_name])
 
         if (element) {
-          debug('    Found as a checked box. id:' + element.id + ' value: checked')
           element.checked = true
           continue
         }
-        warn('Could not find element with name: ' + id_name)
       }
 
       showLoadingMessage(false)
@@ -155,8 +150,6 @@
     }
 
     function init () {
-      debug('Starting init')
-
       google.script.run.withSuccessHandler(showAlert).withFailureHandler(showError).sendWelcomeEmail()
       google.script.run.withSuccessHandler(restorePrefsHandler).withFailureHandler(showError).getPrefs()
       getHandlers().createTriggers()
@@ -189,20 +182,7 @@
             timerLabelDateString.classList.add('bg-danger')
           }
         }).withFailureHandler(showError).parseDateFormat(timerLabelInput.value)
-
       }
-
-    }
-    function debug (msg) {
-      console.log(msg)
-    }
-
-    function warn (msg) {
-      console.warn(msg)
-    }
-
-    function error (msg) {
-      console.error(msg)
     }
     </script>
     <head>

--- a/src/Utils.gs
+++ b/src/Utils.gs
@@ -2,11 +2,8 @@ function getTimeZoneString () {
   var userPrefs = getUserPrefs()
   var timezone_string = userPrefs['localzone']
 
-  debug('User timezone:' + timezone_string)
-
   if (timezone_string == DEFAULT_TIMEZONE) {
     timezone_string = CalendarApp.getDefaultCalendar().getTimeZone()
-    debug('Loading timezone from calendar: ' + timezone_string)
   }
 
   return timezone_string
@@ -16,7 +13,6 @@ function convertToUserDate (date) {
   var user_timezone_string = getTimeZoneString()
   var user_date_string = Utilities.formatDate(date, user_timezone_string, 'yyyy/MM/dd HH:mm:ss')
   var user_date = new Date(user_date_string)
-  debug('Converted:' + date + ' to user time:' + user_date)
   return user_date
 }
 
@@ -31,7 +27,6 @@ function getActiveUserEmail () {
 function userHasLabel (label) {
   labels = GmailApp.getUserLabels()
   for (var i = 0; i < labels.length; i++) {
-    debug('label: ' + labels[i].getName())
     if (labels[i].getName() == label)
       return true
   }
@@ -42,11 +37,8 @@ function createLabel (labelName) {
   var label = GmailApp.createLabel(labelName)
 
   if (label) {
-    debug('New label created successfully')
     return true
   } else {
-    // receipts.push(' Error trying to create a new label: "' + label + '". Cannot continue.  :-(')
-    debug('Error creating label!')
     return false
   }
 }
@@ -56,10 +48,8 @@ function deleteLabel (labelName) {
   var deleteLabelResult = GmailApp.deleteLabel(userLabel)
 
   if (deleteLabelResult) {
-    debug('Label deleted successfully.')
     return true
   } else {
-    debug('Error deleting label!')
     return false
   }
 }
@@ -70,7 +60,6 @@ function createTimerChildLabels (labels) {
   }
 
   return true
-
 }
 
 function createTimerChildLabel (label) {
@@ -88,8 +77,8 @@ function getUserChildLabels (label) {
     if (labels[i].getName().indexOf(label + '/') === 0) {
       childLabels.push(labels[i].getName().replace(label + '/', ''))
     }
-
   }
+
   return childLabels
 }
 
@@ -108,10 +97,6 @@ function parseDateFormat (str) {
   }
 
   return null
-}
-
-function debug (msg) {
-  Logger.log(msg)
 }
 
 function dateConversionRequired (str) {


### PR DESCRIPTION
I'm removing the send message SMS, because right now it simple creates an event one minute before you save the message in drafts, and then sends the SMS. That isn't very helpful for the goal of GmailScheduler. Perhaps, this feature could be added if there were a tag to specify the time in which it should be sent.