### PR TITLE
Catch exception when sending a message that doesn't have a recipient

### DIFF
--- a/src/Main.gs
+++ b/src/Main.gs
@@ -41,8 +41,16 @@ function dispatchDraft (messageId) {
           attachments: message.getAttachments()
       }
 
-      GmailApp.sendEmail(message.getTo(), message.getSubject(), body, options)
-      message.moveToTrash()
+      try{
+        GmailApp.sendEmail(message.getTo(), message.getSubject(), body, options)
+        message.moveToTrash()
+      } catch(err) {
+        if(err.message === "Failed to send email: no recipient"){
+          Logger.log("Failed to send email: no recipient")
+        } else {
+          throw err
+        }
+      }
       return 'Delivered'
     } else {
       return 'Message not found in Drafts'


### PR DESCRIPTION
I added a control exception for sending messages that doesn't have a recipient. Because, if the recipient is empty the function will fail and all the trigger will fail, and the other messages (those with one or more recipients) won't be sent. For now, I just log the error, not sure what it should do. Do you have any suggestions?