### PR TITLE
Add sleep between calls

### DIFF
--- a/src/Utils.gs
+++ b/src/Utils.gs
@@ -127,6 +127,7 @@ function getUserChildLabels (label) {
 }
 
 function parseDate (str) {
+  Utilities.sleep(1000)
   if (dateConversionRequired(str)) {
     return convertToUserDate(Date.future(str))
   }


### PR DESCRIPTION
I just added the sleep between calls (`Utilities.sleep(1000)`)that Google Script suggest before parsing a Date. I hope this solves the problem. In my computer that problem don't show up.