### PR TITLE
Add check for empty input

### DIFF
--- a/src/User_UI.html
+++ b/src/User_UI.html
@@ -150,6 +150,12 @@
       timerLabelInput.onkeyup = function () {
         timerLabelValid = false
 
+        if(timerLabelInput.value.trim() == "") {
+            timerLabelDateString.parentNode.classList.add('hidden')
+        } else {
+            timerLabelDateString.parentNode.classList.remove('hidden')
+        }
+
         document.getElementById('timerLabelDateString').innerHTML = 'Processing date'
 
         google.script.run.withSuccessHandler(function (dateString) {


### PR DESCRIPTION
Hide the `timerLabelDateString` when the `timerLabelInput` is empty or just with spaces.